### PR TITLE
Fix syntax warning about an invalid escape sequence

### DIFF
--- a/inst/service/backend/_utils.py
+++ b/inst/service/backend/_utils.py
@@ -43,7 +43,7 @@ def ver_strip(version):
     version = version.rsplit("-", 1)[0]
     version = version.rsplit("+")[0]
     # remove things like .r79, see r-cran-rniftilib
-    version = re.sub("\.r[0-9]+$", "", version)
+    version = re.sub(r"\.r[0-9]+$", "", version)
     return version
 
 def pkg_record(prefixes, name, version, repo):


### PR DESCRIPTION
With Python 3.12, invalid escape sequences like `\.` in string literals cause a syntax warning:

```
service/backend/_utils.py:46: SyntaxWarning: invalid escape sequence '\.'
  version = re.sub("\.r[0-9]+$", "", version)
```

Fix this by using the raw string notation instead.